### PR TITLE
Fix typo in subnet host discovery

### DIFF
--- a/plugin/providers/phpipam/subnet_structure.go
+++ b/plugin/providers/phpipam/subnet_structure.go
@@ -28,7 +28,7 @@ var resourceSubnetOptionalFields = linearSearchSlice{
 	"allow_ip_requests",
 	"scan_agent_id",
 	"include_in_ping",
-	"host_discover_enabled",
+	"host_discovery_enabled",
 	"is_full",
 	"utilization_threshold",
 }


### PR DESCRIPTION
When creating a subnet, an error occurs when trying to set host discovery. This fixes that typo and allows setting this.