### PR TITLE
Add support for dynamically allocating IP addresses

### DIFF
--- a/plugin/providers/phpipam/address_structure.go
+++ b/plugin/providers/phpipam/address_structure.go
@@ -94,15 +94,19 @@ func bareAddressSchema() map[string]*schema.Schema {
 
 // resourceAddressSchema returns the schema for the phpipam_address resource.
 // It sets the required and optional fields, the latter defined in
-// resourceAddressRequiredFields, and ensures that all optional and
+// resourceAddressOptionalFields, and ensures that all optional and
 // non-configurable fields are computed as well.
 func resourceAddressSchema() map[string]*schema.Schema {
 	s := bareAddressSchema()
 	for k, v := range s {
 		switch {
 		// IP Address and Subnet ID are ForceNew
-		case k == "subnet_id" || k == "ip_address":
+		case k == "subnet_id":
 			v.Required = true
+			v.ForceNew = true
+	  case k == "ip_address":
+			v.Optional = true
+			v.Computed = true
 			v.ForceNew = true
 		case k == "custom_fields":
 			v.Optional = true
@@ -165,7 +169,7 @@ func dataSourceAddressSchema() map[string]*schema.Schema {
 }
 
 // expandAddress returns the addresses.Address structure for a
-// phpiapm_address resource or data source. Depending on if we are dealing with
+// phpipam_address resource or data source. Depending on if we are dealing with
 // the resource or data source, extra considerations may need to be taken.
 func expandAddress(d *schema.ResourceData) addresses.Address {
 	s := addresses.Address{

--- a/plugin/providers/phpipam/config.go
+++ b/plugin/providers/phpipam/config.go
@@ -2,6 +2,7 @@ package phpipam
 
 import (
 	"log"
+	"sync"
 
 	"github.com/pavel-z1/phpipam-sdk-go/controllers/addresses"
 	"github.com/pavel-z1/phpipam-sdk-go/controllers/sections"
@@ -49,6 +50,9 @@ type ProviderPHPIPAMClient struct {
 
 	// The client for the vlans controller.
 	vlansController *vlans.Controller
+
+	// Mutex for free IP address allocation.
+	addressAllocationLock sync.Mutex
 }
 
 // Client configures and returns a fully initialized PingdomClient.

--- a/plugin/providers/phpipam/resource_phpipam_address_test.go
+++ b/plugin/providers/phpipam/resource_phpipam_address_test.go
@@ -21,6 +21,14 @@ resource "phpipam_address" "address" {
 }
 `
 
+const testAccResourcePHPIPAMOptionalAddressConfig = `
+resource "phpipam_address" "address" {
+  subnet_id   = 3
+  description = "Terraform test address"
+  hostname    = "tf-test.cust1.local"
+}
+`
+
 const testAccResourcePHPIPAMAddressCustomFieldConfig = `
 resource "phpipam_address" "address" {
   subnet_id   = 3
@@ -55,6 +63,26 @@ func TestAccResourcePHPIPAMAddress(t *testing.T) {
 					testAccCheckResourcePHPIPAMAddressCreated,
 					resource.TestCheckResourceAttr("phpipam_address.address", "subnet_id", "3"),
 					resource.TestCheckResourceAttr("phpipam_address.address", "ip_address", "10.10.1.10"),
+					resource.TestCheckResourceAttr("phpipam_address.address", "description", "Terraform test address"),
+					resource.TestCheckResourceAttr("phpipam_address.address", "hostname", "tf-test.cust1.local"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourcePHPIPAMOptionalAddress(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourcePHPIPAMAddressDeleted,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccResourcePHPIPAMOptionalAddressConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourcePHPIPAMAddressCreated,
+					resource.TestCheckResourceAttr("phpipam_address.address", "subnet_id", "3"),
+					resource.TestCheckNoResourceAttr("phpipam_address.address", "ip_address"),
 					resource.TestCheckResourceAttr("phpipam_address.address", "description", "Terraform test address"),
 					resource.TestCheckResourceAttr("phpipam_address.address", "hostname", "tf-test.cust1.local"),
 				),


### PR DESCRIPTION
phpIPAM doesn't just support registering specific IP addresses, it also has functions to automatically pick the next available free IP in the given subnet.

This change makes the `ip_address` argument optional. If it is, an available IP address will be picked automatically by phpIPAM.

Developed by @c0deaddict. 