### PR TITLE
Add Nameservers to Subnet structure

### DIFF
--- a/plugin/providers/phpipam/subnet_structure.go
+++ b/plugin/providers/phpipam/subnet_structure.go
@@ -73,6 +73,9 @@ func bareSubnetSchema() map[string]*schema.Schema {
 		"nameserver_id": &schema.Schema{
 			Type: schema.TypeInt,
 		},
+		"nameservers": &schema.Schema{
+			Type: schema.TypeMap,
+		},
 		"show_name": &schema.Schema{
 			Type: schema.TypeBool,
 		},
@@ -112,12 +115,12 @@ func bareSubnetSchema() map[string]*schema.Schema {
 		"edit_date": &schema.Schema{
 			Type: schema.TypeString,
 		},
-                "gateway": &schema.Schema{
-                        Type: schema.TypeMap,
-                },
-                "gateway_id": &schema.Schema{
-                        Type: schema.TypeString,
-                },
+		"gateway": &schema.Schema{
+				Type: schema.TypeMap,
+		},
+		"gateway_id": &schema.Schema{
+				Type: schema.TypeString,
+		},
 		"custom_fields": &schema.Schema{
 			Type: schema.TypeMap,
 		},
@@ -239,6 +242,7 @@ func expandSubnet(d *schema.ResourceData) subnets.Subnet {
 		VRFID:          d.Get("vrf_id").(int),
 		MasterSubnetID: d.Get("master_subnet_id").(int),
 		NameserverID:   d.Get("nameserver_id").(int),
+		Nameservers:    d.Get("nameservers").(map[string]interface {}),
 		ShowName:       phpipam.BoolIntString(d.Get("show_name").(bool)),
 		Permissions:    d.Get("permissions").(string),
 		DNSRecursive:   phpipam.BoolIntString(d.Get("create_ptr_records").(bool)),
@@ -251,8 +255,8 @@ func expandSubnet(d *schema.ResourceData) subnets.Subnet {
 		IsFull:         phpipam.BoolIntString(d.Get("is_full").(bool)),
 		Threshold:      d.Get("utilization_threshold").(int),
 		Location:       d.Get("location_id").(int),
-		Gateway:	d.Get("gateway").(map[string]interface {}),
-		GatewayID:        d.Get("gateway_id").(string),
+		Gateway:	    d.Get("gateway").(map[string]interface {}),
+		GatewayID:      d.Get("gateway_id").(string),
 	}
 
 	return s
@@ -272,6 +276,7 @@ func flattenSubnet(s subnets.Subnet, d *schema.ResourceData) {
 	d.Set("vrf_id", s.VRFID)
 	d.Set("master_subnet_id", s.MasterSubnetID)
 	d.Set("nameserver_id", s.NameserverID)
+	d.Set("nameservers", s.Nameservers)
 	d.Set("show_name", s.ShowName)
 	d.Set("permissions", s.Permissions)
 	d.Set("create_ptr_records", s.DNSRecursive)


### PR DESCRIPTION
I've added Nameservers to `go-phpipam-sdk`, and added the corresponding enhancements to the Terraform provider structure. The result looks like this:

```
# data.phpipam_subnet.test:
data "phpipam_subnet" "test" {
    allow_ip_requests      = false
    create_ptr_records     = false
    description            = "NNN-126"
    description_match      = "NNN-126"
    display_hostnames      = false
    edit_date              = "2022-06-17 10:38:12"
    gateway                = {}
    gateway_id             = "714"
    host_discovery_enabled = false
    id                     = "135"
    include_in_ping        = false
    is_folder              = false
    is_full                = false
    linked_subnet_id       = 0
    location_id            = 0
    master_subnet_id       = 134
    nameserver_id          = 4
    nameservers            = {
        "description" = ""
        "editDate"    = ""
        "id"          = "4"
        "name"        = "External Nameservers"
        "namesrv1"    = "XXX.YYY.76.60;XXX.YYY.76.76"
        "permissions" = "1;3"
    }
    permissions            = jsonencode(
        {
            "2" = "3"
        }
    )
    scan_agent_id          = 0
    section_id             = 3
    show_name              = false
    subnet_address         = "XXX.YYY.79.0"
    subnet_id              = 135
    subnet_mask            = 26
    utilization_threshold  = 0
    vlan_id                = 54
    vrf_id                 = 0
}
```

As such, it is now possible to add the semicolon separated list of nameservers using `data.phpipam_subnet.my_subnet.nameservers.namesrv1`.