### PR TITLE
Add section_id as optional parameter to firstfreesubnet Resource.

### DIFF
--- a/plugin/providers/phpipam/subnet_structure.go
+++ b/plugin/providers/phpipam/subnet_structure.go
@@ -139,6 +139,8 @@ func resourceFirstFreeSubnetSchema() map[string]*schema.Schema {
 		case k == "parent_subnet_id" || k == "subnet_mask":
 			v.Required = true
 			v.ForceNew = true
+		case k == "section_id":
+			v.Optional = true
 		case k == "custom_fields":
 			v.Optional = true
 		case resourceSubnetOptionalFields.Has(k):


### PR DESCRIPTION
Hi,

@pavel-z1 i decided to start with a new PR, since i messed up during the squashing.

As discussed earlier, this adds the `section_id` parameter to the firstfreeSubnet Resource and flags it as an Optional parameter to retain backwards-compatibility.

This fixes #53 

I based it on-top of the current changes in the master branch and tested with those (provider sdk v2).

Can you please have a look ?

Steffen