### PR TITLE
Using subnet in search of free ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ output "address_description" {
 }
 ```
 
+**Example With `subnet_id` when multiple subnets share the same ip ranges :**
+
+```
+data "phpipam_address" "address" {
+  ip_address = "10.10.1.1"
+  subnet_id         = 3
+}
+
+output "address_description" {
+  value = data.phpipam_address.address.description
+}
+```
+
 **Example With `description`:**
 
 ```
@@ -176,7 +189,8 @@ The data source takes the following parameters:
  * `address_id` - The ID of the IP address in the PHPIPAM database.
  * `ip_address` - The actual IP address in PHPIPAM.
  * `subnet_id` - The ID of the subnet that the address resides in. This is
-   required to search on the `description` or `hostname` fields.
+   required to search on the `description` or `hostname` field. Optional if 
+   multiple subnets have the same ip ranges ( multiple subnets behind NAT ) 
  * `description` - The description of the IP address. `subnet_id` is required
    when using this field.
  * `hostname` - The host name of the IP address. `subnet_id` is required when

--- a/plugin/providers/phpipam/data_source_phpipam_address.go
+++ b/plugin/providers/phpipam/data_source_phpipam_address.go
@@ -37,6 +37,17 @@ func dataSourcePHPIPAMAddressRead(d *schema.ResourceData, meta interface{}) erro
 			}
 			return err
 		}
+	
+	case d.Get("ip_address").(string) != "" && d.Get("subnet_id").(int) != 0:
+		 out[0], err = c.GetAddressesByIpInSubnet(d.Get("ip_address").(string), d.Get("subnet_id").(int))
+		if err != nil {
+			if strings.Contains(err.Error(), "Address not found") {
+				log.Printf("[DEBUG] Invalid IP address Seen with IPAddress: " + d.Get("ip_address").(string) + " and SubnetID: " + strconv.Itoa(d.Get("subnet_id").(int)))
+				// IP not found by IP address and subnet id
+				return nil
+			}
+			return err
+		}
 	case d.Get("ip_address").(string) != "":
 		out, err = c.GetAddressesByIP(d.Get("ip_address").(string))
 		if err != nil {

--- a/plugin/providers/phpipam/data_source_phpipam_first_free_subnet_test.go
+++ b/plugin/providers/phpipam/data_source_phpipam_first_free_subnet_test.go
@@ -19,7 +19,7 @@ data "phpipam_first_free_subnet" "next" {
 }
 `
 
-const testAccDataSourcePHPIPAMFirstFreeAddressNoFreeConfig = `
+const testAccDataSourcePHPIPAMFirstFreeSubnetNoFreeConfig = `
 resource "phpipam_subnet" "subnet" {
   section_id     = 1
   subnet_address = "10.10.3.0"
@@ -50,13 +50,13 @@ data "phpipam_first_free_subnet" "next" {
 }
 `
 
-func TestAccDataSourcePHPIPAMFirstFreeAddress(t *testing.T) {
+func TestAccDataSourcePHPIPAMFirstFreeSubnet(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDataSourcePHPIPAMFirstFreeAddressConfig,
+				Config: testAccDataSourcePHPIPAMFirstFreeSubnetConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.phpipam_first_free_subnet.next", "subnet", "10.10.1.0/26"),
 				),
@@ -65,13 +65,13 @@ func TestAccDataSourcePHPIPAMFirstFreeAddress(t *testing.T) {
 	})
 }
 
-func TestAccDataSourcePHPIPAMFirstFreeAddressNoFree(t *testing.T) {
+func TestAccDataSourcePHPIPAMFirstFreeSubnetNoFree(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config:      testAccDataSourcePHPIPAMFirstFreeAddressNoFreeConfig,
+				Config:      testAccDataSourcePHPIPAMFirstFreeSubnetNoFreeConfig,
 				ExpectError: regexp.MustCompile("Subnet has no free IP addresses"),
 			},
 		},

--- a/plugin/providers/phpipam/provider_test.go
+++ b/plugin/providers/phpipam/provider_test.go
@@ -5,29 +5,28 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 var testAccProvider *schema.Provider
-var testAccProviders map[string]terraform.ResourceProvider
+var testAccProviders map[string]*schema.Provider
 
 const envErrMsg = `PHPIPAM_APP_ID, PHPIPAM_ENDPOINT_ADDR, PHPIPAM_PASSWORD, and PHPIPAM_USER_NAME must be set for acceptance tests`
 
 func init() {
-	testAccProvider = Provider().(*schema.Provider)
-	testAccProviders = map[string]terraform.ResourceProvider{
+	testAccProvider = Provider()
+	testAccProviders = map[string]*schema.Provider{
 		"phpipam": testAccProvider,
 	}
 }
 
 func TestProvider(t *testing.T) {
-	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+	if err := Provider().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
 
 func TestProvider_impl(t *testing.T) {
-	var _ terraform.ResourceProvider = Provider()
+	var _ *schema.Provider  = Provider()
 }
 
 func testAccPreCheck(t *testing.T) {

--- a/plugin/providers/phpipam/resource_phpipam_first_free_address.go
+++ b/plugin/providers/phpipam/resource_phpipam_first_free_address.go
@@ -141,7 +141,7 @@ func resourcePHPIPAMFirstFreeAddressCreate(d *schema.ResourceData, meta interfac
 		if len(addrs) != 1 {
 			return errors.New("IP address either missing or multiple results returned by reading IP after creation")
 		}
-
+		
 		d.SetId(strconv.Itoa(addrs[0].ID))
 
 		if _, err := c.UpdateAddressCustomFields(addrs[0].ID, customFields.(map[string]interface{})); err != nil {


### PR DESCRIPTION
Sometimes in the old DB of phpipam there are multiple subnets with the same IP ranges.  I updated the phpipam-sdk-go with the ability to search with in subnet  . The updated provider will use it when the subnet is specified. It is mostly for the first free resource which does not know how to handle identical IP results from multiple subnets.