### PR TITLE
fix(request): don't add body on GET request

### DIFF
--- a/vendor/github.com/pavel-z1/phpipam-sdk-go/phpipam/request/request.go
+++ b/vendor/github.com/pavel-z1/phpipam-sdk-go/phpipam/request/request.go
@@ -146,24 +146,22 @@ func (r *Request) Send() error {
 	}
 
 	switch r.Method {
-	case "OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE":
-		if r.Input != nil {
-			bs, err := json.Marshal(r.Input)
-			log.Debugf("Request Body Debug ................... %s", bs)
-			if err != nil {
-				return fmt.Errorf("Error preparing request data: %s", err)
-			}
-			buf := bytes.NewBuffer(bs)
-			req, err = http.NewRequest(r.Method, fmt.Sprintf("%s/%s%s", r.Session.Config.Endpoint, r.Session.Config.AppID, r.URI), buf)
-		} else {
-			req, err = http.NewRequest(r.Method, fmt.Sprintf("%s/%s%s", r.Session.Config.Endpoint, r.Session.Config.AppID, r.URI), nil)
+	case "OPTIONS", "POST", "PUT", "PATCH", "DELETE":
+		bs, err := json.Marshal(r.Input)
+		log.Debugf("Request Body Debug ................... %s", bs)
+		if err != nil {
+			return fmt.Errorf("Error preparing request data: %s", err)
 		}
-
+		buf := bytes.NewBuffer(bs)
+		req, err = http.NewRequest(r.Method, fmt.Sprintf("%s/%s%s", r.Session.Config.Endpoint, r.Session.Config.AppID, r.URI), buf)
 		req.Header.Add("Content-Type", "application/json")
-		log.Debugf("Request URL Debug ...................Method: %s, UR: %s/%s%s", r.Method, r.Session.Config.Endpoint, r.Session.Config.AppID, r.URI)
+	case "GET":
+		req, err = http.NewRequest(r.Method, fmt.Sprintf("%s/%s%s", r.Session.Config.Endpoint, r.Session.Config.AppID, r.URI), nil)
+
 	default:
 		return fmt.Errorf("API request method %s not supported by PHPIPAM", r.Method)
 	}
+	log.Debugf("Request URL Debug ...................Method: %s, UR: %s/%s%s", r.Method, r.Session.Config.Endpoint, r.Session.Config.AppID, r.URI)
 
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Hello @lord-kyron,

I the latest release the fix provider in the SDK has no been applied.

Terraform logs (we can see the log for the empty body) :
```
2023-05-16T10:23:06.244+0200 [WARN]  unexpected data: registry.terraform.io/lord-kyron/phpipam:stderr="timestamp=2023-05-16T10:23:06.244486814+02:00 level=debug message="Request Body Debug ................... {}""
2023-05-16T10:23:06.244+0200 [WARN]  unexpected data: registry.terraform.io/lord-kyron/phpipam:stderr="timestamp=2023-05-16T10:23:06.24450661+02:00 level=debug message="Request URL Debug ...................Method: GET, UR: https://34.120.140.78/api/terraform/sections/""
2023-05-16T10:23:06.354+0200 [WARN]  unexpected data: registry.terraform.io/lord-kyron/phpipam:stderr="timestamp=2023-05-16T10:23:06.353915011+02:00 level=debug"
2023-05-16T10:23:06.354+0200 [WARN]  unexpected data: registry.terraform.io/lord-kyron/phpipam:stderr="message="Response Body Debug ................... \n<html><head>\n<meta http-equiv=\"content-type\" content=\"text/html;charset=utf-8\">\n<title>400 Bad Request</title>\n</head>\n<body text=#000000 bgcolor=#ffffff>\n<h1>Error: Bad Request</h1>\n<h2>Your client has issued a malformed or illegal request.</h2>\n<h2></h2>\n</body></html>\n""
2023-05-16T10:23:06.354+0200 [WARN]  unexpected data: registry.terraform.io/lord-kyron/phpipam:stderr=
2023-05-16T10:23:06.354+0200 [ERROR] provider.terraform-provider-phpipam_v1.5.0: Response contains error diagnostic: diagnostic_detail= diagnostic_summary="Non-API error (400 Bad Request): 
<html><head>
```

Thanks