### PR TITLE
Add support to disable connection verification during provider initialization

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,17 @@ resource "phpipam_address" "newip" {
 }
 ```
 
+When the provider is initialized, the "sections" API is called to ensure the
+connection to PHPIPAM works as expected.
+To disable this, set the `verify_connection` parameter to false:
+```
+provider "phpipam" {
+  ...
+  verify_connection = false
+  ...
+}
+```
+
 ### Data Sources
 
 - [`phpipam_address`](./data-sources/address.md)

--- a/plugin/providers/phpipam/config.go
+++ b/plugin/providers/phpipam/config.go
@@ -34,6 +34,9 @@ type Config struct {
 
 	// Allow connect to HTTPS without SSL issuer validation
 	Insecure bool
+
+	// Whether to verify connection to PHPIPAM during provider initialization
+	VerifyConnection bool
 }
 
 // ProviderPHPIPAMClient is a structure that contains the client connections
@@ -81,8 +84,10 @@ func (c *Config) Client() (interface{}, error) {
 	}
 
 	// Validate that our conneciton is okay
-	if err := c.ValidateConnection(client.sectionsController); err != nil {
-		return nil, err
+	if c.VerifyConnection {
+		if err := c.ValidateConnection(client.sectionsController); err != nil {
+			return nil, err
+		}
 	}
 
 	return &client, nil

--- a/plugin/providers/phpipam/provider.go
+++ b/plugin/providers/phpipam/provider.go
@@ -38,6 +38,12 @@ func Provider() *schema.Provider {
 				Default:     false,
 				Description: descriptions["insecure"],
 			},
+			"verify_connection": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["verify_connection"],
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -76,16 +82,19 @@ func init() {
 		"username": "The username of the PHPIPAM account",
 		"insecure": "Whether server should be accessed " +
 			"without verifying the TLS certificate.",
+		"verify_connection": "Whether the check connection to" +
+			"PHPIPAM API during provider initialization.",
 	}
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		AppID:    d.Get("app_id").(string),
-		Endpoint: d.Get("endpoint").(string),
-		Password: d.Get("password").(string),
-		Username: d.Get("username").(string),
-		Insecure: d.Get("insecure").(bool),
+		AppID:            d.Get("app_id").(string),
+		Endpoint:         d.Get("endpoint").(string),
+		Password:         d.Get("password").(string),
+		Username:         d.Get("username").(string),
+		Insecure:         d.Get("insecure").(bool),
+		VerifyConnection: d.Get("verify_connection").(bool),
 	}
 	return config.Client()
 }

--- a/plugin/providers/phpipam/provider.go
+++ b/plugin/providers/phpipam/provider.go
@@ -41,7 +41,7 @@ func Provider() *schema.Provider {
 			"verify_connection": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				Default:     true,
 				Description: descriptions["verify_connection"],
 			},
 		},

--- a/plugin/providers/phpipam/provider.go
+++ b/plugin/providers/phpipam/provider.go
@@ -82,7 +82,7 @@ func init() {
 		"username": "The username of the PHPIPAM account",
 		"insecure": "Whether server should be accessed " +
 			"without verifying the TLS certificate.",
-		"verify_connection": "Whether the check connection to" +
+		"verify_connection": "Whether to check connection to" +
 			"PHPIPAM API during provider initialization.",
 	}
 }


### PR DESCRIPTION
The main use case for us is that we're providing a module that integrates with phpipam. The connection details are automatically obtained from a secret source. But, in some use-cases, the connection details will not be available.
We want to be able to (effectively) toggle the provider.

E.g.

```
variable "enable_phpipam_integration" {
  description = "Enable PHPIPAM integration"
  type            = bool
  default        = true
}

data "some_secret_source" "phpipam" {
  count = var.enable_phpipam_integration ? 1 : 0
}

provider "phpipam" {
  url    = var.enable_phpipam_integration ? data.some_secret_source.phpipam[0].url : ""
  app_id = var.enable_phpipam_integration ? data.some_secret_source.phpipam[0].app_id : ""
}

data "phpipam_subnet" {
  for_each = toset(var.enable_phpipam_integration ? ["something"] : [])
}

``` 

This mostly works, but the provider performs the initial connection validation, which causes it to fail.
The PR adds a parameter so we can tell it not to perform the verification, in this use-case:
```

provider "phpipam" {
  url               = var.enable_phpipam_integration ? data.some_secret_source.phpipam[0].url : ""
  app_id            = var.enable_phpipam_integration ? data.some_secret_source.phpipam[0].app_id : ""
  verify_connection = var.enable_phpipam_integration
} 
```