### PR TITLE
Prevent null section_id after creating first_free_subnet resource

### DIFF
--- a/plugin/providers/phpipam/subnet_structure.go
+++ b/plugin/providers/phpipam/subnet_structure.go
@@ -16,6 +16,7 @@ import (
 // Computed. Any field not listed here cannot be supplied by the resource and
 // is solely computed.
 var resourceSubnetOptionalFields = linearSearchSlice{
+	"section_id",
 	"description",
 	"linked_subnet_id",
 	"vlan_id",
@@ -146,8 +147,10 @@ func resourceFirstFreeSubnetSchema() map[string]*schema.Schema {
 			v.ForceNew = true
 		case k == "section_id":
 			v.Optional = true
+			v.Computed = true
 		case k == "custom_fields":
 			v.Optional = true
+			v.Computed = true
 		case resourceSubnetOptionalFields.Has(k):
 			v.Optional = true
 			v.Computed = true


### PR DESCRIPTION
Fix will prevent cases when section_id will be null after creating first_free_subnet resource:
```
Changes to Outputs:
  ~ subnet_test         = {
        id                     = "11"
      ~ section_id             = 1 -> null
        # (28 unchanged attributes hidden)
    }
```