### PR TITLE
Add subnet_ids support to phpipam_first_free_address

### DIFF
--- a/docs/data-sources/first_free_address.md
+++ b/docs/data-sources/first_free_address.md
@@ -13,9 +13,15 @@ resource.
 
 ## Argument Reference
 
-The data source takes the following parameter:
+The data source takes one of the following parameters (exactly one must be set):
 
-- `subnet_id` (Required) - The ID of the subnet that the address resides in.
+- `subnet_id` (Optional) - The ID of the subnet that the address resides in.
+- `subnet_ids` (Optional) - An ordered list of subnet IDs. The data source tries
+  each subnet in turn and returns the first free address found in the first
+  subnet that still has one available. This is useful when you have several
+  small, non-contiguous address blocks and don't mind which one is used. The
+  `subnet_id` attribute is populated with the ID of the subnet that was
+  actually used.
 
 **Example:**
 
@@ -46,6 +52,18 @@ resource "phpipam_address" "newip" {
     ]
   }
 }
+```
+
+**Example: search across several subnets:**
+
+```hcl
+data "phpipam_first_free_address" "next_address" {
+  subnet_ids = [10, 11, 12]
+}
+
+// data.phpipam_first_free_address.next_address.subnet_id contains the ID of
+// the subnet the address was actually allocated from.
+```
 
 // Supply the IP address to an instance. Note that we are also ignoring
 // network_interface here to ensure the IP address does not get re-calculated.

--- a/docs/resources/first_free_address.md
+++ b/docs/resources/first_free_address.md
@@ -11,7 +11,44 @@ instruction. But be carefull, phpIPAM currently has a bug
 Use resource with count option only with limited terraform threads count: `**terraform apply -parallelism=1**`
 .
 
+## Argument Reference
+
+Exactly one of the following two parameters must be set:
+
+- `subnet_id` (Optional) - The ID of the subnet to allocate the address from.
+- `subnet_ids` (Optional) - An ordered list of subnet IDs. The provider tries
+  each subnet in turn and creates the address in the first subnet that still
+  has a free address available. This is useful when you have several small,
+  non-contiguous address blocks and don't mind which one is used. `subnet_id`
+  is populated with the ID of the subnet that was actually used, so it can
+  still be read back with `phpipam_first_free_address.new_ip.subnet_id`.
+
+**Example: allocate from the first available subnet in a list:**
+
+```hcl
+resource "phpipam_first_free_address" "new_ip" {
+  subnet_ids  = [10, 11, 12]
+  hostname    = "vps01.example.internal"
+  description = "Managed by Terraform"
+}
+```
+
+**Migrating an existing resource from `subnet_id` to `subnet_ids`:** switching a
+resource's config from `subnet_id = 10` to `subnet_ids = [10, 11]` does **not**
+force a replacement as long as the subnet currently holding the address (`10`
+in this example) is still part of the `subnet_ids` list - the address doesn't
+need to move, so Terraform leaves it untouched. Removing that subnet from the
+list, however, is a real change of subnet and will still force a replacement.
+
+⚠️ This only works if every ID in `subnet_ids` is already known at plan time.
+If one of the subnets is being created in the *same* `terraform apply` (e.g.
+`subnet_ids = [10, phpipam_subnet.new.subnet_id]` where `phpipam_subnet.new`
+doesn't exist yet), Terraform cannot prove the list is safe and will force a
+replacement anyway. Apply new subnets first (or reference already-existing
+subnets/data sources) before migrating an existing address to `subnet_ids`.
+
 **Example create IPs in loop with `count`:**
+
 
 ```hcl
 // Look up the subnet

--- a/plugin/providers/phpipam/data_source_phpipam_first_free_address.go
+++ b/plugin/providers/phpipam/data_source_phpipam_first_free_address.go
@@ -2,6 +2,7 @@ package phpipam
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -11,8 +12,16 @@ func dataSourcePHPIPAMFirstFreeAddress() *schema.Resource {
 		Read: dataSourcePHPIPAMFirstFreeAddressRead,
 		Schema: map[string]*schema.Schema{
 			"subnet_id": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"subnet_id", "subnet_ids"},
+			},
+			"subnet_ids": &schema.Schema{
+				Type:         schema.TypeList,
+				Optional:     true,
+				Elem:         &schema.Schema{Type: schema.TypeInt},
+				ExactlyOneOf: []string{"subnet_id", "subnet_ids"},
 			},
 			"ip_address": &schema.Schema{
 				Type:     schema.TypeString,
@@ -24,16 +33,30 @@ func dataSourcePHPIPAMFirstFreeAddress() *schema.Resource {
 
 func dataSourcePHPIPAMFirstFreeAddressRead(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*ProviderPHPIPAMClient).subnetsController
-	out, err := c.GetFirstFreeAddress(d.Get("subnet_id").(int))
-	if err != nil {
-		return err
-	}
-	if out == "" {
-		return errors.New("Subnet has no free IP addresses")
+
+	ids := subnetIDsFromResourceData(d)
+
+	var lastErr error
+	for _, id := range ids {
+		out, err := c.GetFirstFreeAddress(id)
+		switch {
+		case err != nil && strings.Contains(err.Error(), "No free addresses found"):
+			lastErr = err
+			continue
+		case err != nil:
+			return err
+		case out == "":
+			continue
+		}
+
+		d.SetId(out)
+		d.Set("ip_address", out)
+		d.Set("subnet_id", id)
+		return nil
 	}
 
-	d.SetId(out)
-	d.Set("ip_address", out)
-
-	return nil
+	if lastErr != nil {
+		return lastErr
+	}
+	return errors.New("Subnet has no free IP addresses")
 }

--- a/plugin/providers/phpipam/data_source_phpipam_first_free_address_test.go
+++ b/plugin/providers/phpipam/data_source_phpipam_first_free_address_test.go
@@ -97,3 +97,127 @@ func TestAccDataSourcePHPIPAMFirstFreeAddressNoFree(t *testing.T) {
 		},
 	})
 }
+
+const testAccDataSourcePHPIPAMFirstFreeAddressSubnetIDsConfig = `
+resource "phpipam_section" "section" {
+  name        = "tf-test"
+  description = "Terraform test section"
+}
+
+resource "phpipam_subnet" "full" {
+  section_id     = phpipam_section.section.section_id
+  subnet_address = "10.10.4.0"
+  subnet_mask    = 30
+}
+
+resource "phpipam_address" "full_1" {
+  subnet_id  = phpipam_subnet.full.subnet_id
+  ip_address = "10.10.4.1"
+}
+
+resource "phpipam_address" "full_2" {
+  subnet_id  = phpipam_subnet.full.subnet_id
+  ip_address = "10.10.4.2"
+}
+
+resource "phpipam_subnet" "free" {
+  section_id     = phpipam_section.section.section_id
+  subnet_address = "10.10.5.0"
+  subnet_mask    = 24
+}
+
+data "phpipam_first_free_address" "next" {
+  subnet_ids = [phpipam_subnet.full.subnet_id, phpipam_subnet.free.subnet_id]
+
+  depends_on = [
+    "phpipam_address.full_1",
+    "phpipam_address.full_2",
+    "phpipam_subnet.free",
+  ]
+}
+`
+
+const testAccDataSourcePHPIPAMFirstFreeAddressSubnetIDsNoFreeConfig = `
+resource "phpipam_section" "section" {
+  name        = "tf-test"
+  description = "Terraform test section"
+}
+
+resource "phpipam_subnet" "full_1" {
+  section_id     = phpipam_section.section.section_id
+  subnet_address = "10.10.6.0"
+  subnet_mask    = 30
+}
+
+resource "phpipam_address" "full_1_addr1" {
+  subnet_id  = phpipam_subnet.full_1.subnet_id
+  ip_address = "10.10.6.1"
+}
+
+resource "phpipam_address" "full_1_addr2" {
+  subnet_id  = phpipam_subnet.full_1.subnet_id
+  ip_address = "10.10.6.2"
+}
+
+resource "phpipam_subnet" "full_2" {
+  section_id     = phpipam_section.section.section_id
+  subnet_address = "10.10.7.0"
+  subnet_mask    = 30
+}
+
+resource "phpipam_address" "full_2_addr1" {
+  subnet_id  = phpipam_subnet.full_2.subnet_id
+  ip_address = "10.10.7.1"
+}
+
+resource "phpipam_address" "full_2_addr2" {
+  subnet_id  = phpipam_subnet.full_2.subnet_id
+  ip_address = "10.10.7.2"
+}
+
+data "phpipam_first_free_address" "next" {
+  subnet_ids = [phpipam_subnet.full_1.subnet_id, phpipam_subnet.full_2.subnet_id]
+
+  depends_on = [
+    "phpipam_address.full_1_addr1",
+    "phpipam_address.full_1_addr2",
+    "phpipam_address.full_2_addr1",
+    "phpipam_address.full_2_addr2",
+  ]
+}
+`
+
+func TestAccDataSourcePHPIPAMFirstFreeAddressSubnetIDs(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			sectionSweep("tf-test", t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourcePHPIPAMFirstFreeAddressSubnetIDsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.phpipam_first_free_address.next", "ip_address", "10.10.5.1"),
+					resource.TestCheckResourceAttrPair("data.phpipam_first_free_address.next", "subnet_id", "phpipam_subnet.free", "subnet_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourcePHPIPAMFirstFreeAddressSubnetIDsNoFree(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			sectionSweep("tf-test", t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      testAccDataSourcePHPIPAMFirstFreeAddressSubnetIDsNoFreeConfig,
+				ExpectError: regexp.MustCompile("No free addresses found"),
+			},
+		},
+	})
+}

--- a/plugin/providers/phpipam/helper.go
+++ b/plugin/providers/phpipam/helper.go
@@ -1,5 +1,7 @@
 package phpipam
 
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 // linearSearchSlice provides a []string with a helper search function.
 type linearSearchSlice []string
 
@@ -12,4 +14,18 @@ func (s *linearSearchSlice) Has(x string) bool {
 		}
 	}
 	return false
+}
+
+// subnetIDsFromResourceData returns the ordered list of subnet IDs to try,
+// supporting both the legacy singular "subnet_id" and the "subnet_ids" list.
+func subnetIDsFromResourceData(d *schema.ResourceData) []int {
+	if raw, ok := d.GetOk("subnet_ids"); ok {
+		list := raw.([]interface{})
+		ids := make([]int, len(list))
+		for i, v := range list {
+			ids[i] = v.(int)
+		}
+		return ids
+	}
+	return []int{d.Get("subnet_id").(int)}
 }

--- a/plugin/providers/phpipam/resource_phpipam_first_free_address.go
+++ b/plugin/providers/phpipam/resource_phpipam_first_free_address.go
@@ -1,9 +1,11 @@
 package phpipam
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -15,11 +17,12 @@ import (
 // read workflow is identical for both the resource and the data source.
 func resourcePHPIPAMFirstFreeAddress() *schema.Resource {
 	return &schema.Resource{
-		Create: resourcePHPIPAMFirstFreeAddressCreate,
-		Read:   dataSourcePHPIPAMAddressRead,
-		Update: resourcePHPIPAMFirstFreeAddressUpdate,
-		Delete: resourcePHPIPAMFirstFreeAddressDelete,
-		Schema: resourceFirstFreeAddressSchema(),
+		Create:        resourcePHPIPAMFirstFreeAddressCreate,
+		Read:          dataSourcePHPIPAMAddressRead,
+		Update:        resourcePHPIPAMFirstFreeAddressUpdate,
+		Delete:        resourcePHPIPAMFirstFreeAddressDelete,
+		CustomizeDiff: resourcePHPIPAMFirstFreeAddressCustomizeDiff,
+		Schema:        resourceFirstFreeAddressSchema(),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -97,10 +100,14 @@ func resourceFirstFreeAddressSchema() map[string]*schema.Schema {
 	s := bareAddressSchema()
 	for k, v := range s {
 		switch {
-		// IP Address and Subnet ID are ForceNew
+		// Subnet ID is ForceNew, and is mutually exclusive with subnet_ids.
+		// It stays Computed so it reflects the subnet actually used once an
+		// address has been allocated from subnet_ids.
 		case k == "subnet_id":
-			v.Required = true
+			v.Optional = true
+			v.Computed = true
 			v.ForceNew = true
+			v.ExactlyOneOf = []string{"subnet_id", "subnet_ids"}
 		case k == "custom_fields":
 			v.Optional = true
 		case resourceAddressOptionalFields.Has(k):
@@ -110,12 +117,65 @@ func resourceFirstFreeAddressSchema() map[string]*schema.Schema {
 			v.Computed = true
 		}
 	}
+	// subnet_ids allows picking the first subnet, in order, that still has a
+	// free address, instead of a single mandatory subnet_id. It is Computed so
+	// resourcePHPIPAMFirstFreeAddressCustomizeDiff can clear its diff when
+	// migrating from subnet_id without forcing a replacement.
+	s["subnet_ids"] = &schema.Schema{
+		Type:         schema.TypeList,
+		Optional:     true,
+		Computed:     true,
+		ForceNew:     true,
+		Elem:         &schema.Schema{Type: schema.TypeInt},
+		ExactlyOneOf: []string{"subnet_id", "subnet_ids"},
+	}
 	return s
 }
 
+// resourcePHPIPAMFirstFreeAddressCustomizeDiff prevents a spurious replacement
+// when a config moves from a single subnet_id to a subnet_ids list that still
+// contains the subnet the address already lives in - the address itself does
+// not need to move, so there is nothing to force a new resource for.
+func resourcePHPIPAMFirstFreeAddressCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	oldSubnetIDRaw, _ := d.GetChange("subnet_id")
+	currentSubnetID := oldSubnetIDRaw.(int)
+	if currentSubnetID == 0 {
+		return nil
+	}
+
+	// subnet_ids is Optional+Computed, so GetOk alone would happily fall back
+	// to its last known state value even when the config only sets subnet_id
+	// (e.g. when genuinely moving to a different subnet). Only reconcile when
+	// subnet_ids is actually present in the raw config.
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() {
+		return nil
+	}
+	subnetIDsInConfig := rawConfig.GetAttr("subnet_ids")
+	if subnetIDsInConfig.IsNull() || !subnetIDsInConfig.IsKnown() {
+		return nil
+	}
+
+	rawIDs, ok := d.GetOk("subnet_ids")
+	if !ok {
+		return nil
+	}
+
+	for _, v := range rawIDs.([]interface{}) {
+		if v.(int) == currentSubnetID {
+			if err := d.Clear("subnet_id"); err != nil {
+				return err
+			}
+			return d.Clear("subnet_ids")
+		}
+	}
+
+	return nil
+}
+
 func resourcePHPIPAMFirstFreeAddressCreate(d *schema.ResourceData, meta interface{}) error {
-	// Get first free IP from provided subnet_id
-	subnet_id := d.Get("subnet_id").(int)
+	// Try subnet_ids (or the single subnet_id) in order until one has a free address.
+	ids := subnetIDsFromResourceData(d)
 	d.Set("subnet_id", nil)
 
 	// Get address controller and start address creation
@@ -123,11 +183,28 @@ func resourcePHPIPAMFirstFreeAddressCreate(d *schema.ResourceData, meta interfac
 
 	in := expandAddress(d)
 
-	out, err := c.CreateFirstFreeAddress(subnet_id, in)
-	if err != nil {
-		return err
+	var out string
+	var err error
+	found := false
+	for _, id := range ids {
+		out, err = c.CreateFirstFreeAddress(id, in)
+		switch {
+		case err != nil && strings.Contains(err.Error(), "No free addresses found"):
+			continue
+		case err != nil:
+			return err
+		}
+		found = true
+		break
+	}
+	if !found {
+		return fmt.Errorf("No free IP addresses found in any of the provided subnets: %s", err)
 	}
 	d.Set("ip_address", out)
+	// Persist the candidate list so future plans see subnet_ids as already
+	// known and don't treat it as still-to-be-computed (which, combined with
+	// ForceNew, would force a replacement on every plan).
+	d.Set("subnet_ids", ids)
 
 	// If we have custom fields, set them now. We need to get the IP address's ID
 	// beforehand.

--- a/plugin/providers/phpipam/resource_phpipam_first_free_address_customizediff_test.go
+++ b/plugin/providers/phpipam/resource_phpipam_first_free_address_customizediff_test.go
@@ -1,0 +1,139 @@
+package phpipam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// buildRawConfig turns a plain values map into a cty.Value conforming to the
+// resource's implied schema type, so it can be used as InstanceState.RawConfig
+// - mirroring what the real Terraform protocol layer does before calling
+// into CustomizeDiff. Fields not present in values are left null, matching an
+// attribute that's genuinely absent from the HCL config.
+func buildRawConfig(t *testing.T, res *schema.Resource, values map[string]interface{}) cty.Value {
+	t.Helper()
+
+	attrTypes := res.CoreConfigSchema().ImpliedType().AttributeTypes()
+	vals := make(map[string]cty.Value, len(attrTypes))
+
+	for name, at := range attrTypes {
+		v, ok := values[name]
+		if !ok {
+			vals[name] = cty.NullVal(at)
+			continue
+		}
+
+		switch {
+		case at == cty.String:
+			vals[name] = cty.StringVal(v.(string))
+		case at == cty.Number:
+			vals[name] = cty.NumberIntVal(int64(v.(int)))
+		case at == cty.Bool:
+			vals[name] = cty.BoolVal(v.(bool))
+		case at.IsListType() || at.IsSetType():
+			raw := v.([]interface{})
+			elemType := at.ElementType()
+			elems := make([]cty.Value, len(raw))
+			for i, e := range raw {
+				switch elemType {
+				case cty.Number:
+					elems[i] = cty.NumberIntVal(int64(e.(int)))
+				case cty.String:
+					elems[i] = cty.StringVal(e.(string))
+				default:
+					t.Fatalf("unsupported element type for %s: %s", name, elemType.FriendlyName())
+				}
+			}
+			switch {
+			case len(elems) == 0:
+				vals[name] = cty.ListValEmpty(elemType)
+			case at.IsSetType():
+				vals[name] = cty.SetVal(elems)
+			default:
+				vals[name] = cty.ListVal(elems)
+			}
+		default:
+			t.Fatalf("unsupported type for %s: %s", name, at.FriendlyName())
+		}
+	}
+
+	return cty.ObjectVal(vals)
+}
+
+// TestResourcePHPIPAMFirstFreeAddressCustomizeDiff exercises
+// resourcePHPIPAMFirstFreeAddressCustomizeDiff directly against the SDK's
+// diffing engine, without needing a live PHPIPAM server. It guards against
+// two past regressions: a genuine subnet_id change must still force a
+// replacement, and a config-only migration to an equivalent subnet_ids list
+// must not.
+func TestResourcePHPIPAMFirstFreeAddressCustomizeDiff(t *testing.T) {
+	res := resourcePHPIPAMFirstFreeAddress()
+
+	priorStateAttrs := map[string]interface{}{
+		"subnet_id":   139,
+		"subnet_ids":  []interface{}{139},
+		"ip_address":  "10.10.15.1",
+		"address_id":  5000,
+		"hostname":    "tf-test.cust1.local",
+		"description": "Terraform test address",
+	}
+
+	cases := []struct {
+		name            string
+		config          map[string]interface{}
+		wantRequiresNew bool
+	}{
+		{
+			name: "changing subnet_id alone still forces a replacement",
+			config: map[string]interface{}{
+				"subnet_id":   140,
+				"hostname":    "tf-test.cust1.local",
+				"description": "Terraform test address",
+			},
+			wantRequiresNew: true,
+		},
+		{
+			name: "moving to subnet_ids that still contains the current subnet is a no-op",
+			config: map[string]interface{}{
+				"subnet_ids":  []interface{}{139, 140},
+				"hostname":    "tf-test.cust1.local",
+				"description": "Terraform test address",
+			},
+			wantRequiresNew: false,
+		},
+		{
+			name: "moving to subnet_ids without the current subnet still forces a replacement",
+			config: map[string]interface{}{
+				"subnet_ids":  []interface{}{140, 150},
+				"hostname":    "tf-test.cust1.local",
+				"description": "Terraform test address",
+			},
+			wantRequiresNew: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, res.Schema, priorStateAttrs)
+			d.SetId("5000")
+			state := d.State()
+			state.RawConfig = buildRawConfig(t, res, tc.config)
+
+			cfg := terraform.NewResourceConfigRaw(tc.config)
+
+			diff, err := res.SimpleDiff(context.Background(), state, cfg, nil)
+			if err != nil {
+				t.Fatalf("diff error: %s", err)
+			}
+
+			requiresNew := diff != nil && diff.RequiresNew()
+			if requiresNew != tc.wantRequiresNew {
+				t.Fatalf("wantRequiresNew=%v, got %v; diff: %#v", tc.wantRequiresNew, requiresNew, diff)
+			}
+		})
+	}
+}

--- a/plugin/providers/phpipam/resource_phpipam_first_free_address_test.go
+++ b/plugin/providers/phpipam/resource_phpipam_first_free_address_test.go
@@ -1,0 +1,217 @@
+package phpipam
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const testAccResourcePHPIPAMFirstFreeAddressConfig = `
+resource "phpipam_section" "section" {
+  name        = "tf-test"
+  description = "Terraform test section"
+}
+
+resource "phpipam_subnet" "subnet" {
+  section_id     = phpipam_section.section.section_id
+  subnet_address = "10.10.8.0"
+  subnet_mask    = 24
+}
+
+resource "phpipam_first_free_address" "next" {
+  subnet_id   = phpipam_subnet.subnet.subnet_id
+  hostname    = "tf-test.cust1.local"
+  description = "Terraform test address"
+
+  depends_on = [phpipam_subnet.subnet]
+}
+`
+
+const testAccResourcePHPIPAMFirstFreeAddressSubnetIDsConfig = `
+resource "phpipam_section" "section" {
+  name        = "tf-test"
+  description = "Terraform test section"
+}
+
+resource "phpipam_subnet" "full" {
+  section_id     = phpipam_section.section.section_id
+  subnet_address = "10.10.9.0"
+  subnet_mask    = 30
+}
+
+resource "phpipam_address" "full_1" {
+  subnet_id  = phpipam_subnet.full.subnet_id
+  ip_address = "10.10.9.1"
+}
+
+resource "phpipam_address" "full_2" {
+  subnet_id  = phpipam_subnet.full.subnet_id
+  ip_address = "10.10.9.2"
+}
+
+resource "phpipam_subnet" "free" {
+  section_id     = phpipam_section.section.section_id
+  subnet_address = "10.10.10.0"
+  subnet_mask    = 24
+}
+
+resource "phpipam_first_free_address" "next" {
+  subnet_ids  = [phpipam_subnet.full.subnet_id, phpipam_subnet.free.subnet_id]
+  hostname    = "tf-test.cust1.local"
+  description = "Terraform test address"
+
+  depends_on = [
+    "phpipam_address.full_1",
+    "phpipam_address.full_2",
+    "phpipam_subnet.free",
+  ]
+}
+`
+
+func TestAccResourcePHPIPAMFirstFreeAddress(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			sectionSweep("tf-test", t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccResourcePHPIPAMFirstFreeAddressConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("phpipam_first_free_address.next", "ip_address", "10.10.8.1"),
+					resource.TestCheckResourceAttrPair("phpipam_first_free_address.next", "subnet_id", "phpipam_subnet.subnet", "subnet_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourcePHPIPAMFirstFreeAddressSubnetIDs(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			sectionSweep("tf-test", t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccResourcePHPIPAMFirstFreeAddressSubnetIDsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("phpipam_first_free_address.next", "ip_address", "10.10.10.1"),
+					resource.TestCheckResourceAttrPair("phpipam_first_free_address.next", "subnet_id", "phpipam_subnet.free", "subnet_id"),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourcePHPIPAMFirstFreeAddressMigrateStep1Config = `
+resource "phpipam_section" "section" {
+  name        = "tf-test"
+  description = "Terraform test section"
+}
+
+resource "phpipam_subnet" "a" {
+  section_id     = phpipam_section.section.section_id
+  subnet_address = "10.10.15.0"
+  subnet_mask    = 24
+}
+
+// Created up-front (but unused by the address yet) so that its subnet_id is
+// already known by the time step 2 switches to subnet_ids - otherwise the
+// still-to-be-created subnet keeps the whole subnet_ids list "unknown" at
+// plan time and the CustomizeDiff can't tell it's a safe, no-op migration.
+resource "phpipam_subnet" "b" {
+  section_id     = phpipam_section.section.section_id
+  subnet_address = "10.10.16.0"
+  subnet_mask    = 24
+}
+
+resource "phpipam_first_free_address" "next" {
+  subnet_id   = phpipam_subnet.a.subnet_id
+  hostname    = "tf-test.cust1.local"
+  description = "Terraform test address"
+
+  depends_on = [phpipam_subnet.a, phpipam_subnet.b]
+}
+`
+
+const testAccResourcePHPIPAMFirstFreeAddressMigrateStep2Config = `
+resource "phpipam_section" "section" {
+  name        = "tf-test"
+  description = "Terraform test section"
+}
+
+resource "phpipam_subnet" "a" {
+  section_id     = phpipam_section.section.section_id
+  subnet_address = "10.10.15.0"
+  subnet_mask    = 24
+}
+
+resource "phpipam_subnet" "b" {
+  section_id     = phpipam_section.section.section_id
+  subnet_address = "10.10.16.0"
+  subnet_mask    = 24
+}
+
+resource "phpipam_first_free_address" "next" {
+  subnet_ids  = [phpipam_subnet.a.subnet_id, phpipam_subnet.b.subnet_id]
+  hostname    = "tf-test.cust1.local"
+  description = "Terraform test address"
+
+  depends_on = [phpipam_subnet.a, phpipam_subnet.b]
+}
+`
+
+// TestAccResourcePHPIPAMFirstFreeAddressMigrateToSubnetIDs ensures that
+// switching a resource's config from subnet_id to a subnet_ids list that
+// still contains the current subnet is a no-op (no replacement), since the
+// address does not need to move. See resourcePHPIPAMFirstFreeAddressCustomizeDiff.
+func TestAccResourcePHPIPAMFirstFreeAddressMigrateToSubnetIDs(t *testing.T) {
+	var firstID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			sectionSweep("tf-test", t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccResourcePHPIPAMFirstFreeAddressMigrateStep1Config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("phpipam_first_free_address.next", "ip_address", "10.10.15.1"),
+					func(s *terraform.State) error {
+						r, ok := s.RootModule().Resources["phpipam_first_free_address.next"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						firstID = r.Primary.ID
+						return nil
+					},
+				),
+			},
+			resource.TestStep{
+				Config: testAccResourcePHPIPAMFirstFreeAddressMigrateStep2Config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("phpipam_first_free_address.next", "ip_address", "10.10.15.1"),
+					resource.TestCheckResourceAttrPair("phpipam_first_free_address.next", "subnet_id", "phpipam_subnet.a", "subnet_id"),
+					func(s *terraform.State) error {
+						r, ok := s.RootModule().Resources["phpipam_first_free_address.next"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						if r.Primary.ID != firstID {
+							return fmt.Errorf("expected address to be preserved (id %s), got a new one (%s) - resource was replaced", firstID, r.Primary.ID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+


### PR DESCRIPTION
Adds an optional `subnet_ids` argument to both the `phpipam_first_free_address` resource and data source, as an alternative to the existing single `subnet_id`.

* When `subnet_ids` is set, the provider tries each subnet in the given order and allocates the address in the first one that still has a free IP available. Useful when address space is split across several small, non-contiguous subnets instead of one large one.
* `subnet_id` is untouched and fully backward compatible - existing configs keep working with no changes. Exactly one of `subnet_id` / `subnet_ids` must be set (Terraform fails plan/apply with a clear error otherwise).
* Added a `CustomizeDiff` so that migrating an existing resource from `subnet_id = 10` to `subnet_ids = [10, 11]` does not force a replacement when the subnet currently holding the address (`10`) is still in the list - the address doesn't need to move. Removing that subnet from the list is still treated as a real change and forces a replacement, as before. This only works when every ID in `subnet_ids` is already known at plan time (documented in the resource docs).
* Updated `docs/resources/first_free_address.md` and `docs/data-sources/first_free_address.md` with the new argument, an example, and the migration/limitation notes.

Tests added:
* `TestAccDataSourcePHPIPAMFirstFreeAddressSubnetIDs` / `...SubnetIDsNoFree` - data source with multiple subnets.
* `TestAccResourcePHPIPAMFirstFreeAddressSubnetIDs` - resource with multiple subnets.
* `TestAccResourcePHPIPAMFirstFreeAddressMigrateToSubnetIDs` - confirms migrating an existing resource from `subnet_id` to `subnet_ids` does not replace it (same resource id/IP before and after).
* `TestResourcePHPIPAMFirstFreeAddressCustomizeDiff` - fast, server-less unit test covering: a genuine `subnet_id` change still forces a replacement, an equivalent `subnet_ids` migration doesn't, and a `subnet_ids` list without the current subnet still forces a replacement.

All existing tests pass unchanged.